### PR TITLE
fix: sticker undo ordering, panel drag, transformer deselect, and pan…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,14 +144,12 @@ function App() {
         return;
       }
       const newSticker = createStickerDescriptor(def);
-      setStickers((prev) => {
-        const newStickers = [...prev, newSticker];
-        pushState(latestSnapshotRef.current ?? "");
-        stickerHistory.pushState(newStickers);
-        return newStickers;
-      });
+      const newStickers = [...stickers, newSticker];
+      setStickers(newStickers);
+      pushState(latestSnapshotRef.current ?? "");
+      stickerHistory.pushState(newStickers);
     },
-    [createStickerDescriptor, pushState, stickerHistory],
+    [stickers, createStickerDescriptor, pushState, stickerHistory],
   );
 
   const handleSpeechBubblePlace = useCallback(
@@ -159,17 +157,15 @@ function App() {
       const def = pendingTextStickerRef.current;
       if (def) {
         const newSticker = createStickerDescriptor(def, text);
-        setStickers((prev) => {
-          const newStickers = [...prev, newSticker];
-          pushState(latestSnapshotRef.current ?? "");
-          stickerHistory.pushState(newStickers);
-          return newStickers;
-        });
+        const newStickers = [...stickers, newSticker];
+        setStickers(newStickers);
+        pushState(latestSnapshotRef.current ?? "");
+        stickerHistory.pushState(newStickers);
         pendingTextStickerRef.current = null;
       }
       setShowSpeechBubbleModal(false);
     },
-    [createStickerDescriptor, pushState, stickerHistory],
+    [stickers, createStickerDescriptor, pushState, stickerHistory],
   );
 
   const handleSpeechBubbleCancel = useCallback(() => {
@@ -179,27 +175,23 @@ function App() {
 
   const handleUpdateSticker = useCallback(
     (desc: StickerDescriptor) => {
-      setStickers((prev) => {
-        const newStickers = prev.map((s) => (s.id === desc.id ? desc : s));
-        pushState(latestSnapshotRef.current ?? "");
-        stickerHistory.pushState(newStickers);
-        return newStickers;
-      });
+      const newStickers = stickers.map((s) => (s.id === desc.id ? desc : s));
+      setStickers(newStickers);
+      pushState(latestSnapshotRef.current ?? "");
+      stickerHistory.pushState(newStickers);
     },
-    [pushState, stickerHistory],
+    [stickers, pushState, stickerHistory],
   );
 
   const handleDeleteSticker = useCallback(
     (id: string) => {
-      setStickers((prev) => {
-        const newStickers = prev.filter((s) => s.id !== id);
-        pushState(latestSnapshotRef.current ?? "");
-        stickerHistory.pushState(newStickers);
-        return newStickers;
-      });
+      const newStickers = stickers.filter((s) => s.id !== id);
+      setStickers(newStickers);
+      pushState(latestSnapshotRef.current ?? "");
+      stickerHistory.pushState(newStickers);
       setSelectedStickerId((prev) => (prev === id ? null : prev));
     },
-    [pushState, stickerHistory],
+    [stickers, pushState, stickerHistory],
   );
 
   const handleSelectSticker = useCallback((id: string | null) => {
@@ -209,13 +201,10 @@ function App() {
   const handleToggleFrame = useCallback(
     (id: string) => {
       setActiveFrameId((prev) => (prev === id ? null : id));
-      setStickers((prev) => {
-        pushState(latestSnapshotRef.current ?? "");
-        stickerHistory.pushState(prev);
-        return prev;
-      });
+      pushState(latestSnapshotRef.current ?? "");
+      stickerHistory.pushState(stickers);
     },
-    [pushState, stickerHistory],
+    [stickers, pushState, stickerHistory],
   );
 
   const selectedStickerIdRef = useRef(selectedStickerId);

--- a/src/components/DecoratePanel.css
+++ b/src/components/DecoratePanel.css
@@ -1,7 +1,7 @@
 .decorate-panel {
-  width: 120px;
-  background: var(--card-bg, #1e1e2e);
-  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  width: 180px;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -10,7 +10,7 @@
 
 .decorate-panel__tabs {
   display: flex;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--border);
 }
 
 .decorate-panel__tab {
@@ -27,7 +27,7 @@
 
 .decorate-panel__tab--active {
   color: #fff;
-  border-bottom-color: #fe81d4;
+  border-bottom-color: var(--accent);
 }
 
 .decorate-panel__content {
@@ -55,7 +55,7 @@
 
 .decorate-panel__grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 6px;
 }
 
@@ -77,12 +77,12 @@
 }
 
 .decorate-panel__item--active {
-  border-color: hotpink;
+  border-color: var(--accent);
 }
 
 .decorate-panel__item img {
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   object-fit: contain;
 }
 
@@ -91,7 +91,7 @@
   color: rgba(255, 255, 255, 0.6);
   text-align: center;
   line-height: 1.2;
-  max-width: 52px;
+  max-width: 44px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/DecoratePanel.tsx
+++ b/src/components/DecoratePanel.tsx
@@ -91,7 +91,7 @@ export function DecoratePanel({
                   onClick={() => onPlaceSticker(def)}
                   title={def.label}
                 >
-                  <img src={def.src} alt={def.label} />
+                  <img src={def.src} alt={def.label} draggable={false} />
                   <span className="decorate-panel__item-label">
                     {def.label}
                   </span>
@@ -104,7 +104,7 @@ export function DecoratePanel({
                   onClick={() => onPlaceSticker(def)}
                   title={def.label}
                 >
-                  <img src={def.src} alt={def.label} />
+                  <img src={def.src} alt={def.label} draggable={false} />
                   <span className="decorate-panel__item-label">
                     {def.label}
                   </span>

--- a/src/components/EmojiCanvas.tsx
+++ b/src/components/EmojiCanvas.tsx
@@ -319,12 +319,19 @@ export function EmojiCanvas({
 
   const handleClick = useCallback(
     (e: Konva.KonvaEventObject<MouseEvent>) => {
-      if (e.target === e.target.getStage()) {
+      const target = e.target;
+      const isStickerNode = [...stickerNodeRefs.current.values()].some(
+        (node) => node === target,
+      );
+      const isTransformerPart =
+        target instanceof Konva.Transformer ||
+        target.getParent() instanceof Konva.Transformer;
+      if (!isStickerNode && !isTransformerPart) {
         onSelectSticker?.(null);
       }
       if (activeTool !== "text") return;
       if (textInputPos) return;
-      const stage = e.target.getStage();
+      const stage = target.getStage();
       const pos = stage?.getPointerPosition();
       if (!pos) return;
       setTextInputPos({ x: pos.x, y: pos.y });


### PR DESCRIPTION
fix styling

- Move history pushes outside setStickers updater functions so React StrictMode's double-invocation doesn't create duplicate history entries, which caused undo to appear out-of-order or skip actions entirely
- Add draggable={false} to panel sticker images so accidentally dragging them onto the canvas no longer replaces the main image via the drop handler
- Deselect sticker (dismiss transformer) on any canvas click that isn't a sticker node or transformer anchor, not just clicks directly on the Stage
- Widen DecoratePanel from 120px to 180px with a 3-column grid so stickers are visible without scrolling; wire colors to design tokens (--surface, --border, --accent) instead of hardcoded / missing CSS variables